### PR TITLE
Added compatibility with Console requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ The format of this changelog is based on ["Keep a Changelog"](http://keepachange
 This project adheres to [Semantic Versioning](http://semver.org/). Version numbers follow the pattern: `MAJOR.FEATURE.BUILD`
 
 
+## 3.0.3 - 2018-09-17
+
+### Added
+
+- Added compatibility with Console requests. ([#1](https://github.com/TopShelfCraft/New-Relic/issues/1))
+
+### Changed
+
+- Removed leading slash from transaction names in Live Preview and Console requests.
+
 ## 3.0.2 - 2018-06-27
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "topshelfcraft/new-relic",
     "description": "This plugin helps instrument your Craft app with New Relic APM by setting transaction names and (optionally) an App Name on each request.",
     "type": "craft-plugin",
-    "version": "3.0.2",
+    "version": "3.0.3",
     "keywords": [
         "craft",
         "cms",


### PR DESCRIPTION
Remove Leading slash from transaction names in Live Preview and Console requests.